### PR TITLE
Fix HTML section syntax and enhance setup script

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+jquery.min.js
+lunr.min.js
+turn.min.js
+aos.js
+aos.css
+.eslintrc.json
+.github/workflows/ci.yml
+README.md
+tsconfig.json
+eslint.config.js

--- a/schedule8-masterpiece.html
+++ b/schedule8-masterpiece.html
@@ -1,25 +1,42 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Schedule 8 - Labour Relations Act | A Gift from Advocate Nandi Basson</title>
-    
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      Schedule 8 - Labour Relations Act | A Gift from Advocate Nandi Basson
+    </title>
+
     <!-- PWA Manifest -->
-    <link rel="manifest" href="manifest.json">
-    <meta name="theme-color" content="#1C2833">
-    <link rel="apple-touch-icon" href="icon-192.png">
-    
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#1C2833" />
+    <link rel="apple-touch-icon" href="icon-192.png" />
+
     <!-- Professional Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
     <!-- Icons -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/css/page-flip.browser.min.css">
-    <link rel='stylesheet' href='aos.css'>
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/css/page-flip.browser.min.css"
+    />
+    <link rel="stylesheet" href="aos.css" />
     <!-- Animation & Book Libraries -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/css/page-flip.min.css">
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/css/page-flip.min.css"
+    />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/js/page-flip.browser.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.8/ScrollMagic.min.js"></script>
@@ -30,1254 +47,1327 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/4.0.15/fullpage.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/openseadragon/5.0.1/openseadragon.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/epub.js/0.3.93/epub.min.js"></script>
-    
+
     <style>
-        :root {
-            /* Professional Legal Color Palette */
-            --primary-navy: #1C2833;
-            --secondary-slate: #2E4053;
-            --accent-gold: #D4AF37;
-            --text-primary: #2C3E50;
-            --text-secondary: #5D6D7E;
-            --background-light: #FDFEFE;
-            --background-section: #F8F9FA;
-            --border-subtle: #E8EAED;
-            --success-green: #27AE60;
-            --warning-amber: #F39C12;
-            
-            /* Typography Scale */
-            --font-display: 'Playfair Display', serif;
-            --font-body: 'Inter', sans-serif;
-            
-            /* Spacing Scale */
-            --space-xs: 0.5rem;
-            --space-sm: 1rem;
-            --space-md: 1.5rem;
-            --space-lg: 2rem;
-            --space-xl: 3rem;
-            --space-2xl: 4rem;
-            
-            /* Animation Easing */
-            --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
-            --ease-out: cubic-bezier(0, 0, 0.2, 1);
-            --ease-spring: cubic-bezier(0.68, -0.55, 0.265, 1.55);
-        }
+      :root {
+          /* Professional Legal Color Palette */
+          --primary-navy: #1C2833;
+          --secondary-slate: #2E4053;
+          --accent-gold: #D4AF37;
+          --text-primary: #2C3E50;
+          --text-secondary: #5D6D7E;
+          --background-light: #FDFEFE;
+          --background-section: #F8F9FA;
+          --border-subtle: #E8EAED;
+          --success-green: #27AE60;
+          --warning-amber: #F39C12;
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+          /* Typography Scale */
+          --font-display: 'Playfair Display', serif;
+          --font-body: 'Inter', sans-serif;
 
-        body {
-            font-family: var(--font-body);
-            line-height: 1.6;
-            color: var(--text-primary);
-            background: var(--background-light);
-            overflow-x: hidden;
-        }
+          /* Spacing Scale */
+          --space-xs: 0.5rem;
+          --space-sm: 1rem;
+          --space-md: 1.5rem;
+          --space-lg: 2rem;
+          --space-xl: 3rem;
+          --space-2xl: 4rem;
 
-        /* Elegant Loading Animation */
-        .loading-screen {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(135deg, var(--primary-navy) 0%, var(--secondary-slate) 100%);
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            z-index: 9999;
-            transition: opacity 0.8s var(--ease-out), visibility 0.8s;
-        }
+          /* Animation Easing */
+          --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+          --ease-out: cubic-bezier(0, 0, 0.2, 1);
+          --ease-spring: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+      }
 
-        .loading-screen.hidden {
-            opacity: 0;
-            visibility: hidden;
-        }
+      * {
+          margin: 0;
+          padding: 0;
+          box-sizing: border-box;
+      }
 
-        .loading-logo {
-            font-family: var(--font-display);
-            font-size: 3rem;
-            font-weight: 700;
-            color: white;
-            text-align: center;
-            margin-bottom: var(--space-lg);
-        }
+      body {
+          font-family: var(--font-body);
+          line-height: 1.6;
+          color: var(--text-primary);
+          background: var(--background-light);
+          overflow-x: hidden;
+      }
 
-        .loading-subtitle {
-            color: var(--accent-gold);
-            font-size: 1.2rem;
-            font-weight: 300;
-            text-align: center;
-            margin-bottom: var(--space-xl);
-        }
+      /* Elegant Loading Animation */
+      .loading-screen {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: linear-gradient(135deg, var(--primary-navy) 0%, var(--secondary-slate) 100%);
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          z-index: 9999;
+          transition: opacity 0.8s var(--ease-out), visibility 0.8s;
+      }
 
-        .loading-spinner {
-            width: 60px;
-            height: 60px;
-            border: 3px solid rgba(255, 255, 255, 0.3);
-            border-top: 3px solid var(--accent-gold);
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-        }
+      .loading-screen.hidden {
+          opacity: 0;
+          visibility: hidden;
+      }
 
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
+      .loading-logo {
+          font-family: var(--font-display);
+          font-size: 3rem;
+          font-weight: 700;
+          color: white;
+          text-align: center;
+          margin-bottom: var(--space-lg);
+      }
 
-        /* Hero Section with Sophisticated Design */
-        .hero {
-            min-height: 100vh;
-            background: linear-gradient(135deg, var(--primary-navy) 0%, var(--secondary-slate) 100%);
-            display: flex;
-            align-items: center;
-            position: relative;
-            overflow: hidden;
-        }
+      .loading-subtitle {
+          color: var(--accent-gold);
+          font-size: 1.2rem;
+          font-weight: 300;
+          text-align: center;
+          margin-bottom: var(--space-xl);
+      }
 
-        .hero::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="20" cy="20" r="1" fill="white" opacity="0.1"/><circle cx="80" cy="80" r="1" fill="white" opacity="0.08"/><circle cx="40" cy="60" r="1" fill="white" opacity="0.06"/></pattern></defs><rect width="100%" height="100%" fill="url(%23grain)"/></svg>');
-            pointer-events: none;
-        }
+      .loading-spinner {
+          width: 60px;
+          height: 60px;
+          border: 3px solid rgba(255, 255, 255, 0.3);
+          border-top: 3px solid var(--accent-gold);
+          border-radius: 50%;
+          animation: spin 1s linear infinite;
+      }
 
-        .hero-container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 0 var(--space-lg);
-            position: relative;
-            z-index: 2;
-        }
+      @keyframes spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+      }
 
-        .hero-content {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: var(--space-2xl);
-            align-items: center;
-        }
+      /* Hero Section with Sophisticated Design */
+      .hero {
+          min-height: 100vh;
+          background: linear-gradient(135deg, var(--primary-navy) 0%, var(--secondary-slate) 100%);
+          display: flex;
+          align-items: center;
+          position: relative;
+          overflow: hidden;
+      }
 
-        .hero-text h1 {
-            font-family: var(--font-display);
-            font-size: clamp(3rem, 5vw, 4.5rem);
-            font-weight: 700;
-            color: white;
-            line-height: 1.1;
-            margin-bottom: var(--space-md);
-            opacity: 0;
-            transform: translateY(30px);
-            animation: slideUp 1s var(--ease-out) 0.5s forwards;
-        }
+      .hero::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="20" cy="20" r="1" fill="white" opacity="0.1"/><circle cx="80" cy="80" r="1" fill="white" opacity="0.08"/><circle cx="40" cy="60" r="1" fill="white" opacity="0.06"/></pattern></defs><rect width="100%" height="100%" fill="url(%23grain)"/></svg>');
+          pointer-events: none;
+      }
 
-        .hero-subtitle {
-            font-size: 1.5rem;
-            color: var(--accent-gold);
-            font-weight: 300;
-            margin-bottom: var(--space-lg);
-            opacity: 0;
-            transform: translateY(30px);
-            animation: slideUp 1s var(--ease-out) 0.7s forwards;
-        }
+      .hero-container {
+          max-width: 1200px;
+          margin: 0 auto;
+          padding: 0 var(--space-lg);
+          position: relative;
+          z-index: 2;
+      }
 
-        .hero-description {
-            font-size: 1.1rem;
-            color: rgba(255, 255, 255, 0.9);
-            line-height: 1.8;
-            margin-bottom: var(--space-xl);
-            opacity: 0;
-            transform: translateY(30px);
-            animation: slideUp 1s var(--ease-out) 0.9s forwards;
-        }
+      .hero-content {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--space-2xl);
+          align-items: center;
+      }
 
-        .advocate-signature {
-            font-family: var(--font-display);
-            font-size: 1.3rem;
-            color: var(--accent-gold);
-            font-style: italic;
-            opacity: 0;
-            transform: translateY(30px);
-            animation: slideUp 1s var(--ease-out) 1.1s forwards;
-        }
+      .hero-text h1 {
+          font-family: var(--font-display);
+          font-size: clamp(3rem, 5vw, 4.5rem);
+          font-weight: 700;
+          color: white;
+          line-height: 1.1;
+          margin-bottom: var(--space-md);
+          opacity: 0;
+          transform: translateY(30px);
+          animation: slideUp 1s var(--ease-out) 0.5s forwards;
+      }
 
-        .hero-visual {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            opacity: 0;
-            transform: scale(0.8);
-            animation: scaleIn 1s var(--ease-spring) 1.3s forwards;
-        }
+      .hero-subtitle {
+          font-size: 1.5rem;
+          color: var(--accent-gold);
+          font-weight: 300;
+          margin-bottom: var(--space-lg);
+          opacity: 0;
+          transform: translateY(30px);
+          animation: slideUp 1s var(--ease-out) 0.7s forwards;
+      }
 
-        .document-preview {
-            width: 400px;
-            height: 500px;
-            background: white;
-            border-radius: 20px;
-            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-            position: relative;
-            overflow: hidden;
-            transform: perspective(1000px) rotateY(-10deg) rotateX(5deg);
-        }
+      .hero-description {
+          font-size: 1.1rem;
+          color: rgba(255, 255, 255, 0.9);
+          line-height: 1.8;
+          margin-bottom: var(--space-xl);
+          opacity: 0;
+          transform: translateY(30px);
+          animation: slideUp 1s var(--ease-out) 0.9s forwards;
+      }
 
-        .document-header {
-            background: var(--primary-navy);
-            color: white;
-            padding: var(--space-md);
-            text-align: center;
-        }
+      .advocate-signature {
+          font-family: var(--font-display);
+          font-size: 1.3rem;
+          color: var(--accent-gold);
+          font-style: italic;
+          opacity: 0;
+          transform: translateY(30px);
+          animation: slideUp 1s var(--ease-out) 1.1s forwards;
+      }
 
-        .document-title {
-            font-family: var(--font-display);
-            font-size: 1.5rem;
-            font-weight: 600;
-        }
+      .hero-visual {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          opacity: 0;
+          transform: scale(0.8);
+          animation: scaleIn 1s var(--ease-spring) 1.3s forwards;
+      }
 
-        .document-content {
-            padding: var(--space-lg);
-            font-size: 0.9rem;
-            line-height: 1.6;
-            color: var(--text-primary);
-        }
+      .document-preview {
+          width: 400px;
+          height: 500px;
+          background: white;
+          border-radius: 20px;
+          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+          position: relative;
+          overflow: hidden;
+          transform: perspective(1000px) rotateY(-10deg) rotateX(5deg);
+      }
 
-        .section-number {
-            font-family: var(--font-display);
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--accent-gold);
-            margin-bottom: var(--space-sm);
-        }
+      .document-header {
+          background: var(--primary-navy);
+          color: white;
+          padding: var(--space-md);
+          text-align: center;
+      }
 
-        @keyframes slideUp {
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
+      .document-title {
+          font-family: var(--font-display);
+          font-size: 1.5rem;
+          font-weight: 600;
+      }
 
-        @keyframes scaleIn {
-            to {
-                opacity: 1;
-                transform: scale(1);
-            }
-        }
+      .document-content {
+          padding: var(--space-lg);
+          font-size: 0.9rem;
+          line-height: 1.6;
+          color: var(--text-primary);
+      }
 
-        /* Navigation Bar */
-        .navbar {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            background: rgba(28, 40, 51, 0.95);
-            backdrop-filter: blur(10px);
-            z-index: 1000;
-            transition: transform 0.3s var(--ease-out);
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-        }
+      .section-number {
+          font-family: var(--font-display);
+          font-size: 2rem;
+          font-weight: 700;
+          color: var(--accent-gold);
+          margin-bottom: var(--space-sm);
+      }
 
-        .navbar.hidden {
-            transform: translateY(-100%);
-        }
+      @keyframes slideUp {
+          to {
+              opacity: 1;
+              transform: translateY(0);
+          }
+      }
 
-        .nav-container {
-            max-width: 1200px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: var(--space-sm) var(--space-lg);
-        }
+      @keyframes scaleIn {
+          to {
+              opacity: 1;
+              transform: scale(1);
+          }
+      }
 
-        .nav-logo {
-            font-family: var(--font-display);
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: white;
-            text-decoration: none;
-        }
+      /* Navigation Bar */
+      .navbar {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          background: rgba(28, 40, 51, 0.95);
+          backdrop-filter: blur(10px);
+          z-index: 1000;
+          transition: transform 0.3s var(--ease-out);
+          border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      }
 
-        .nav-links {
-            display: flex;
-            list-style: none;
-            gap: var(--space-lg);
-        }
-        .nav-search input {
-            padding: 0.25rem 0.5rem;
-            border-radius: 4px;
-            border: 1px solid var(--border-subtle);
-            font-size: 0.9rem;
-        }
+      .navbar.hidden {
+          transform: translateY(-100%);
+      }
 
-        .nav-links a {
-            color: white;
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.3s var(--ease-out);
-            position: relative;
-        }
+      .nav-container {
+          max-width: 1200px;
+          margin: 0 auto;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: var(--space-sm) var(--space-lg);
+      }
 
-        .nav-links a:hover {
-            color: var(--accent-gold);
-        }
+      .nav-logo {
+          font-family: var(--font-display);
+          font-size: 1.5rem;
+          font-weight: 700;
+          color: white;
+          text-decoration: none;
+      }
 
-        .nav-links a::after {
-            content: '';
-            position: absolute;
-            bottom: -5px;
-            left: 0;
-            width: 0;
-            height: 2px;
-            background: var(--accent-gold);
-            transition: width 0.3s var(--ease-out);
-        }
+      .nav-links {
+          display: flex;
+          list-style: none;
+          gap: var(--space-lg);
+      }
+      .nav-search input {
+          padding: 0.25rem 0.5rem;
+          border-radius: 4px;
+          border: 1px solid var(--border-subtle);
+          font-size: 0.9rem;
+      }
 
-        .nav-links a:hover::after {
-            width: 100%;
-        }
+      .nav-links a {
+          color: white;
+          text-decoration: none;
+          font-weight: 500;
+          transition: color 0.3s var(--ease-out);
+          position: relative;
+      }
 
-        /* Content Sections */
-        .section {
-            padding: var(--space-2xl) 0;
-            max-width: 1200px;
-            margin: 0 auto;
-            padding-left: var(--space-lg);
-            padding-right: var(--space-lg);
-            opacity: 0;
-            transform: translateY(20px);
-            transition: all 0.6s var(--ease-out);
-        }
+      .nav-links a:hover {
+          color: var(--accent-gold);
+      }
 
-        .section.visible {
-            opacity: 1;
-            transform: none;
-        }
+      .nav-links a::after {
+          content: '';
+          position: absolute;
+          bottom: -5px;
+          left: 0;
+          width: 0;
+          height: 2px;
+          background: var(--accent-gold);
+          transition: width 0.3s var(--ease-out);
+      }
 
-        .section-title {
-            font-family: var(--font-display);
-            font-size: 2.5rem;
-            font-weight: 700;
-            color: var(--primary-navy);
-            margin-bottom: var(--space-lg);
-            text-align: center;
-        }
+      .nav-links a:hover::after {
+          width: 100%;
+      }
 
-        .section-subtitle {
-            font-size: 1.2rem;
-            color: var(--text-secondary);
-            text-align: center;
-            margin-bottom: var(--space-xl);
-            max-width: 600px;
-            margin-left: auto;
-            margin-right: auto;
-        }
+      /* Content Sections */
+      .section {
+          padding: var(--space-2xl) 0;
+          max-width: 1200px;
+          margin: 0 auto;
+          padding-left: var(--space-lg);
+          padding-right: var(--space-lg);
+          opacity: 0;
+          transform: translateY(20px);
+          transition: all 0.6s var(--ease-out);
+      }
 
-        /* Interactive Schedule Grid */
-        .schedule-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-            gap: var(--space-lg);
-            margin-top: var(--space-xl);
-        }
+      .section.visible {
+          opacity: 1;
+          transform: none;
+      }
 
-        .schedule-card {
-            background: white;
-            border-radius: 15px;
-            padding: var(--space-lg);
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s var(--ease-out);
-            cursor: pointer;
-            border: 2px solid transparent;
-            position: relative;
-            overflow: hidden;
-        }
+      .section-title {
+          font-family: var(--font-display);
+          font-size: 2.5rem;
+          font-weight: 700;
+          color: var(--primary-navy);
+          margin-bottom: var(--space-lg);
+          text-align: center;
+      }
 
-        .schedule-card::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 4px;
-            background: linear-gradient(90deg, var(--accent-gold), var(--primary-navy));
-            transform: scaleX(0);
-            transition: transform 0.3s var(--ease-out);
-        }
+      .section-subtitle {
+          font-size: 1.2rem;
+          color: var(--text-secondary);
+          text-align: center;
+          margin-bottom: var(--space-xl);
+          max-width: 600px;
+          margin-left: auto;
+          margin-right: auto;
+      }
 
-        .schedule-card:hover {
-            transform: translateY(-10px);
-            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
-            border-color: var(--accent-gold);
-        }
+      /* Interactive Schedule Grid */
+      .schedule-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+          gap: var(--space-lg);
+          margin-top: var(--space-xl);
+      }
 
-        .schedule-card:hover::before {
-            transform: scaleX(1);
-        }
+      .schedule-card {
+          background: white;
+          border-radius: 15px;
+          padding: var(--space-lg);
+          box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+          transition: all 0.3s var(--ease-out);
+          cursor: pointer;
+          border: 2px solid transparent;
+          position: relative;
+          overflow: hidden;
+      }
 
-        .card-number {
-            font-family: var(--font-display);
-            font-size: 3rem;
-            font-weight: 700;
-            color: var(--accent-gold);
-            line-height: 1;
-            margin-bottom: var(--space-sm);
-        }
+      .schedule-card::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: 4px;
+          background: linear-gradient(90deg, var(--accent-gold), var(--primary-navy));
+          transform: scaleX(0);
+          transition: transform 0.3s var(--ease-out);
+      }
 
-        .card-title {
-            font-size: 1.3rem;
-            font-weight: 600;
-            color: var(--primary-navy);
-            margin-bottom: var(--space-sm);
-        }
+      .schedule-card:hover {
+          transform: translateY(-10px);
+          box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+          border-color: var(--accent-gold);
+      }
 
-        .card-description {
-            color: var(--text-secondary);
-            line-height: 1.6;
-            margin-bottom: var(--space-md);
-        }
+      .schedule-card:hover::before {
+          transform: scaleX(1);
+      }
 
-        .card-footer {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding-top: var(--space-md);
-            border-top: 1px solid var(--border-subtle);
-        }
+      .card-number {
+          font-family: var(--font-display);
+          font-size: 3rem;
+          font-weight: 700;
+          color: var(--accent-gold);
+          line-height: 1;
+          margin-bottom: var(--space-sm);
+      }
 
-        .read-more {
-            color: var(--primary-navy);
-            font-weight: 600;
-            text-decoration: none;
-            display: flex;
-            align-items: center;
-            gap: var(--space-xs);
-            transition: gap 0.3s var(--ease-out);
-        }
+      .card-title {
+          font-size: 1.3rem;
+          font-weight: 600;
+          color: var(--primary-navy);
+          margin-bottom: var(--space-sm);
+      }
 
-        .read-more:hover {
-            gap: var(--space-sm);
-            color: var(--accent-gold);
-        }
+      .card-description {
+          color: var(--text-secondary);
+          line-height: 1.6;
+          margin-bottom: var(--space-md);
+      }
 
-        /* Professional Footer */
-        .footer {
-            background: var(--primary-navy);
-            color: white;
-            text-align: center;
-            padding: var(--space-2xl) var(--space-lg);
-            margin-top: var(--space-2xl);
-        }
+      .card-footer {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding-top: var(--space-md);
+          border-top: 1px solid var(--border-subtle);
+      }
 
-        .footer-content {
-            max-width: 800px;
-            margin: 0 auto;
-        }
+      .read-more {
+          color: var(--primary-navy);
+          font-weight: 600;
+          text-decoration: none;
+          display: flex;
+          align-items: center;
+          gap: var(--space-xs);
+          transition: gap 0.3s var(--ease-out);
+      }
 
-        .footer-title {
-            font-family: var(--font-display);
-            font-size: 2rem;
-            font-weight: 700;
-            margin-bottom: var(--space-md);
-            color: var(--accent-gold);
-        }
+      .read-more:hover {
+          gap: var(--space-sm);
+          color: var(--accent-gold);
+      }
 
-        .footer-message {
-            font-size: 1.1rem;
-            line-height: 1.8;
-            margin-bottom: var(--space-lg);
-            opacity: 0.9;
-        }
+      /* Professional Footer */
+      .footer {
+          background: var(--primary-navy);
+          color: white;
+          text-align: center;
+          padding: var(--space-2xl) var(--space-lg);
+          margin-top: var(--space-2xl);
+      }
 
-        .contact-info {
-            display: flex;
-            justify-content: center;
-            gap: var(--space-lg);
-            margin-bottom: var(--space-lg);
-            flex-wrap: wrap;
-        }
+      .footer-content {
+          max-width: 800px;
+          margin: 0 auto;
+      }
 
-        .contact-item {
-            display: flex;
-            align-items: center;
-            gap: var(--space-xs);
-            color: var(--accent-gold);
-        }
+      .footer-title {
+          font-family: var(--font-display);
+          font-size: 2rem;
+          font-weight: 700;
+          margin-bottom: var(--space-md);
+          color: var(--accent-gold);
+      }
 
-        .workshop-date {
-            font-family: var(--font-display);
-            font-size: 1.5rem;
-            font-weight: 600;
-            color: var(--accent-gold);
-            margin-top: var(--space-lg);
-        }
+      .footer-message {
+          font-size: 1.1rem;
+          line-height: 1.8;
+          margin-bottom: var(--space-lg);
+          opacity: 0.9;
+      }
 
-        /* Responsive Design */
-        @media (max-width: 768px) {
-            .hero-content {
-                grid-template-columns: 1fr;
-                text-align: center;
-            }
-            
-            .hero-text h1 {
-                font-size: 2.5rem;
-            }
-            
-            .document-preview {
-                width: 300px;
-                height: 400px;
-            }
-            
-            .nav-links {
-                display: none;
-            }
-            
-            .schedule-grid {
-                grid-template-columns: 1fr;
-            }
-            
-            .contact-info {
-                flex-direction: column;
-                align-items: center;
-            }
-        }
+      .contact-info {
+          display: flex;
+          justify-content: center;
+          gap: var(--space-lg);
+          margin-bottom: var(--space-lg);
+          flex-wrap: wrap;
+      }
 
-        /* Smooth Scrolling */
-        html {
-            scroll-behavior: smooth;
-        }
+      .contact-item {
+          display: flex;
+          align-items: center;
+          gap: var(--space-xs);
+          color: var(--accent-gold);
+      }
 
-        /* Custom Scrollbar */
-        ::-webkit-scrollbar {
-            width: 8px;
-        }
+      .workshop-date {
+          font-family: var(--font-display);
+          font-size: 1.5rem;
+          font-weight: 600;
+          color: var(--accent-gold);
+          margin-top: var(--space-lg);
+      }
 
-        ::-webkit-scrollbar-track {
-            background: var(--background-section);
-        }
+      /* Responsive Design */
+      @media (max-width: 768px) {
+          .hero-content {
+              grid-template-columns: 1fr;
+              text-align: center;
+          }
 
-        ::-webkit-scrollbar-thumb {
-            background: var(--accent-gold);
-            border-radius: 4px;
-        }
+          .hero-text h1 {
+              font-size: 2.5rem;
+          }
 
-        ::-webkit-scrollbar-thumb:hover {
-            background: var(--primary-navy);
-        }
-        /* Flipbook Styles */
-        .flipbook-section {
-            padding: var(--space-xl) 0;
-            background: var(--background-section);
-            text-align: center;
-        }
-        .flipbook {
-            width: 90%;
-            margin: 0 auto;
-        }
-        .flipbook .page {
-            background: #fff;
-            border: 1px solid var(--border-subtle);
-            padding: var(--space-md);
-        .search-bar {
-            margin-top: var(--space-sm);
-            text-align: center;
-        }
-        #searchInput {
-            padding: 0.5rem 1rem;
-            width: 100%;
-            max-width: 400px;
-            border: 1px solid var(--border-subtle);
-            border-radius: 30px;
-        }
-        #searchResults {
-            margin-top: var(--space-sm);
-        }
-        .search-result {
-            background: var(--background-section);
-            padding: 1rem;
-            border-radius: 8px;
-            margin-bottom: 0.5rem;
-        }
-        .flipbook {
-            width: 100%;
-            height: 400px;
-            margin: 2rem auto;
-        }
-        .flipbook .page {
-            width: 100%;
-            height: 100%;
-            background: white;
-            border-radius: 10px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-            padding: 2rem;
-        /* Flipbook Styles */
-        .my-flipbook {
-            width: 100%;
-            max-width: 600px;
-            height: 400px;
-            margin: var(--space-xl) auto;
-        }
-        .page {
-            background: white;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            padding: var(--space-lg);
-        }
-        .page h3 {
-            font-family: var(--font-display);
-            font-size: 1.5rem;
-            margin-bottom: var(--space-md);
-            color: var(--primary-navy);
-        }
-        .page p {
-            font-size: 0.95rem;
-            line-height: 1.6;
-        }
-        }
+          .document-preview {
+              width: 300px;
+              height: 400px;
+          }
+
+          .nav-links {
+              display: none;
+          }
+
+          .schedule-grid {
+              grid-template-columns: 1fr;
+          }
+
+          .contact-info {
+              flex-direction: column;
+              align-items: center;
+          }
+      }
+
+      /* Smooth Scrolling */
+      html {
+          scroll-behavior: smooth;
+      }
+
+      /* Custom Scrollbar */
+      ::-webkit-scrollbar {
+          width: 8px;
+      }
+
+      ::-webkit-scrollbar-track {
+          background: var(--background-section);
+      }
+
+      ::-webkit-scrollbar-thumb {
+          background: var(--accent-gold);
+          border-radius: 4px;
+      }
+
+      ::-webkit-scrollbar-thumb:hover {
+          background: var(--primary-navy);
+      }
+      /* Flipbook Styles */
+      .flipbook-section {
+          padding: var(--space-xl) 0;
+          background: var(--background-section);
+          text-align: center;
+      }
+      .flipbook {
+          width: 90%;
+          margin: 0 auto;
+      }
+      .flipbook .page {
+          background: #fff;
+          border: 1px solid var(--border-subtle);
+          padding: var(--space-md);
+      .search-bar {
+          margin-top: var(--space-sm);
+          text-align: center;
+      }
+      #searchInput {
+          padding: 0.5rem 1rem;
+          width: 100%;
+          max-width: 400px;
+          border: 1px solid var(--border-subtle);
+          border-radius: 30px;
+      }
+      #searchResults {
+          margin-top: var(--space-sm);
+      }
+      .search-result {
+          background: var(--background-section);
+          padding: 1rem;
+          border-radius: 8px;
+          margin-bottom: 0.5rem;
+      }
+      .flipbook {
+          width: 100%;
+          height: 400px;
+          margin: 2rem auto;
+      }
+      .flipbook .page {
+          width: 100%;
+          height: 100%;
+          background: white;
+          border-radius: 10px;
+          box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+          padding: 2rem;
+      /* Flipbook Styles */
+      .my-flipbook {
+          width: 100%;
+          max-width: 600px;
+          height: 400px;
+          margin: var(--space-xl) auto;
+      }
+      .page {
+          background: white;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          padding: var(--space-lg);
+      }
+      .page h3 {
+          font-family: var(--font-display);
+          font-size: 1.5rem;
+          margin-bottom: var(--space-md);
+          color: var(--primary-navy);
+      }
+      .page p {
+          font-size: 0.95rem;
+          line-height: 1.6;
+      }
+      }
     </style>
     <!-- Libraries for interactive features -->
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turn.js/4.1.0/turn.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js"></script>
-</head>
-<body>
+  </head>
+  <body>
     <!-- Loading Screen -->
     <div class="loading-screen" id="loadingScreen">
-        <div class="loading-logo">Schedule 8</div>
-        <div class="loading-subtitle">Labour Relations Act</div>
-        <div class="loading-spinner"></div>
+      <div class="loading-logo">Schedule 8</div>
+      <div class="loading-subtitle">Labour Relations Act</div>
+      <div class="loading-spinner"></div>
     </div>
 
     <!-- Navigation -->
     <nav class="navbar" id="navbar">
-        <div class="nav-container">
-            <a href="#" class="nav-logo">Schedule 8 | LRA</a>
-            <ul class="nav-links">
-                <li><a href="#home">Home</a></li>
-                <li><a href="#sections">Sections</a></li>
-                <li><a href="#guide">Quick Guide</a></li>
-                <li><a href="#contact">Contact</a></li>
-            </ul>
-            <div class="nav-search">
-                <input type="text" id="searchBox" placeholder="Search Schedule 8...">
-            </div>
+      <div class="nav-container">
+        <a href="#" class="nav-logo">Schedule 8 | LRA</a>
+        <ul class="nav-links">
+          <li><a href="#home">Home</a></li>
+          <li><a href="#sections">Sections</a></li>
+          <li><a href="#guide">Quick Guide</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+        <div class="nav-search">
+          <input
+            type="text"
+            id="searchBox"
+            placeholder="Search Schedule 8..."
+          />
         </div>
+      </div>
     </nav>
 
     <!-- Hero Section -->
     <section class="hero" id="home">
-        <div class="hero-container">
-            <div class="hero-content">
-                <div class="hero-text">
-                    <h1>Schedule 8<br>Labour Relations Act</h1>
-                    <div class="hero-subtitle"><span id="typed-subtitle"></span></div>
-                    <p class="hero-description">
-                        A comprehensive, interactive reference for HR professionals, managers, and legal practitioners. 
-                        Navigate South Africa's employment discipline framework with confidence and precision.
-                    </p>
-                    <div class="advocate-signature">
-                        — A gift from Advocate Nandi Basson
-                    </div>
-                    <div class="search-bar">
-                        <input type="text" id="searchInput" placeholder="Search Schedule 8..." />
-                        <div id="searchResults"></div>
-                    </div>
-                </div>
-                <div class="hero-visual">
-                    <div id="hero-animation" style="width:150px;height:150px;margin-right:1rem;"></div>
-                    <div class="document-preview">
-                        <div class="document-header">
-                            <div class="document-title">Schedule 8</div>
-                        </div>
-                        <div class="document-content" id="flipbook">
-                            <div class="section-number">8.1</div>
-                            <p><strong>Guidelines:</strong> Dismissals must be both substantively and procedurally fair...</p>
-                            <div class="section-number" style="margin-top: 1rem;">8.2</div>
-                            <p><strong>Disciplinary Action:</strong> Progressive discipline should be applied...</p>
-                            <div class="section-number" style="margin-top: 1rem;">8.3</div>
-                            <p><strong>Misconduct:</strong> Examples include dishonesty, insubordination...</p>
-                        </div>
-                    </div>
-                </div>
+      <div class="hero-container">
+        <div class="hero-content">
+          <div class="hero-text">
+            <h1>Schedule 8<br />Labour Relations Act</h1>
+            <div class="hero-subtitle"><span id="typed-subtitle"></span></div>
+            <p class="hero-description">
+              A comprehensive, interactive reference for HR professionals,
+              managers, and legal practitioners. Navigate South Africa's
+              employment discipline framework with confidence and precision.
+            </p>
+            <div class="advocate-signature">
+              — A gift from Advocate Nandi Basson
             </div>
+            <div class="search-bar">
+              <input
+                type="text"
+                id="searchInput"
+                placeholder="Search Schedule 8..."
+              />
+              <div id="searchResults"></div>
+            </div>
+          </div>
+          <div class="hero-visual">
+            <div
+              id="hero-animation"
+              style="width: 150px; height: 150px; margin-right: 1rem"
+            ></div>
+            <div class="document-preview">
+              <div class="document-header">
+                <div class="document-title">Schedule 8</div>
+              </div>
+              <div class="document-content" id="flipbook">
+                <div class="section-number">8.1</div>
+                <p>
+                  <strong>Guidelines:</strong> Dismissals must be both
+                  substantively and procedurally fair...
+                </p>
+                <div class="section-number" style="margin-top: 1rem">8.2</div>
+                <p>
+                  <strong>Disciplinary Action:</strong> Progressive discipline
+                  should be applied...
+                </p>
+                <div class="section-number" style="margin-top: 1rem">8.3</div>
+                <p>
+                  <strong>Misconduct:</strong> Examples include dishonesty,
+                  insubordination...
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
     </section>
 
     <!-- Sections Overview -->
     <section class="section" id="sections">
-        <h2 class="section-title">Interactive Schedule 8 Sections</h2>
-        <p class="section-subtitle">
-            Click on any section to explore detailed guidelines, case law references, and practical applications
-        </p>
-        
-        <div class="schedule-grid">
-            <div class="schedule-card" onclick="openSection(1)" data-section="1">
-            <div class="schedule-card" data-aos="fade-up" onclick="openSection(1)">
-                <div class="card-number">8.1</div>
-                <h3 class="card-title">General Guidelines</h3>
-                <p class="card-description">
-                    Fundamental principles for fair dismissal procedures, including substantive and procedural fairness requirements.
-                </p>
-                <div class="card-footer">
-                    <a href="#" class="read-more">
-                        Explore Section <i class="fas fa-arrow-right"></i>
-                    </a>
-                    <span style="color: var(--success-green); font-weight: 600;">
-                        <i class="fas fa-check-circle"></i> Essential
-                    </span>
-                </div>
-            </div>
+      <h2 class="section-title">Interactive Schedule 8 Sections</h2>
+      <p class="section-subtitle">
+        Click on any section to explore detailed guidelines, case law
+        references, and practical applications
+      </p>
 
-            <div class="schedule-card" onclick="openSection(2)" data-section="2">
-            <div class="schedule-card" data-aos="fade-up" onclick="openSection(2)">
-                <div class="card-number">8.2</div>
-                <h3 class="card-title">Disciplinary Action</h3>
-                <p class="card-description">
-                    Progressive discipline framework, corrective measures, and appropriate responses to different levels of misconduct.
-                </p>
-                <div class="card-footer">
-                    <a href="#" class="read-more">
-                        Explore Section <i class="fas fa-arrow-right"></i>
-                    </a>
-                    <span style="color: var(--warning-amber); font-weight: 600;">
-                        <i class="fas fa-star"></i> Practical
-                    </span>
-                </div>
-            </div>
-
-            <div class="schedule-card" onclick="openSection(3)" data-section="3">
-            <div class="schedule-card" data-aos="fade-up" onclick="openSection(3)">
-                <div class="card-number">8.3</div>
-                <h3 class="card-title">Misconduct Examples</h3>
-                <p class="card-description">
-                    Comprehensive examples of misconduct categories, severity levels, and appropriate disciplinary responses.
-                </p>
-                <div class="card-footer">
-                    <a href="#" class="read-more">
-                        Explore Section <i class="fas fa-arrow-right"></i>
-                    </a>
-                    <span style="color: var(--success-green); font-weight: 600;">
-                        <i class="fas fa-book"></i> Reference
-                    </span>
-                </div>
-            </div>
-
-            <div class="schedule-card" onclick="openSection(4)" data-section="4">
-            <div class="schedule-card" data-aos="fade-up" onclick="openSection(4)">
-                <div class="card-number">8.4</div>
-                <h3 class="card-title">Incapacity Dismissals</h3>
-                <p class="card-description">
-                    Guidelines for dismissals based on poor performance, ill-health, and other incapacity-related issues.
-                </p>
-                <div class="card-footer">
-                    <a href="#" class="read-more">
-                        Explore Section <i class="fas fa-arrow-right"></i>
-                    </a>
-                    <span style="color: var(--warning-amber); font-weight: 600;">
-                        <i class="fas fa-clipboard-check"></i> Complex
-                    </span>
-                </div>
-            </div>
-
-            <div class="schedule-card" onclick="openSection(5)" data-section="5">
-            <div class="schedule-card" data-aos="fade-up" onclick="openSection(5)">
-                <div class="card-number">8.5</div>
-                <h3 class="card-title">Operational Requirements</h3>
-                <p class="card-description">
-                    Retrenchment procedures, consultation requirements, and fair selection criteria for operational dismissals.
-                </p>
-                <div class="card-footer">
-                    <a href="#" class="read-more">
-                        Explore Section <i class="fas fa-arrow-right"></i>
-                    </a>
-                    <span style="color: var(--success-green); font-weight: 600;">
-                        <i class="fas fa-users"></i> Critical
-                    </span>
-                </div>
-            </div>
-
-            <div class="schedule-card" onclick="openSection(6)" data-section="6">
-            <div class="schedule-card" data-aos="fade-up" onclick="openSection(6)">
-                <div class="card-number">8.6</div>
-                <h3 class="card-title">Automatically Unfair Dismissals</h3>
-                <p class="card-description">
-                    Protected reasons and circumstances where dismissals are automatically considered unfair under the LRA.
-                </p>
-                <div class="card-footer">
-                    <a href="#" class="read-more">
-                        Explore Section <i class="fas fa-arrow-right"></i>
-                    </a>
-                    <span style="color: var(--warning-amber); font-weight: 600;">
-                        <i class="fas fa-shield-alt"></i> Protected
-                    </span>
-                </div>
-            </div>
+      <div class="schedule-grid">
+        <div
+          class="schedule-card"
+          data-aos="fade-up"
+          onclick="openSection(1)"
+          data-section="1"
+        >
+          <div class="card-number">8.1</div>
+          <h3 class="card-title">General Guidelines</h3>
+          <p class="card-description">
+            Fundamental principles for fair dismissal procedures, including
+            substantive and procedural fairness requirements.
+          </p>
+          <div class="card-footer">
+            <a href="#" class="read-more">
+              Explore Section <i class="fas fa-arrow-right"></i>
+            </a>
+            <span style="color: var(--success-green); font-weight: 600">
+              <i class="fas fa-check-circle"></i> Essential
+            </span>
+          </div>
         </div>
+
+        <div
+          class="schedule-card"
+          data-aos="fade-up"
+          onclick="openSection(2)"
+          data-section="2"
+        >
+          <div class="card-number">8.2</div>
+          <h3 class="card-title">Disciplinary Action</h3>
+          <p class="card-description">
+            Progressive discipline framework, corrective measures, and
+            appropriate responses to different levels of misconduct.
+          </p>
+          <div class="card-footer">
+            <a href="#" class="read-more">
+              Explore Section <i class="fas fa-arrow-right"></i>
+            </a>
+            <span style="color: var(--warning-amber); font-weight: 600">
+              <i class="fas fa-star"></i> Practical
+            </span>
+          </div>
+        </div>
+
+        <div
+          class="schedule-card"
+          data-aos="fade-up"
+          onclick="openSection(3)"
+          data-section="3"
+        >
+          <div class="card-number">8.3</div>
+          <h3 class="card-title">Misconduct Examples</h3>
+          <p class="card-description">
+            Comprehensive examples of misconduct categories, severity levels,
+            and appropriate disciplinary responses.
+          </p>
+          <div class="card-footer">
+            <a href="#" class="read-more">
+              Explore Section <i class="fas fa-arrow-right"></i>
+            </a>
+            <span style="color: var(--success-green); font-weight: 600">
+              <i class="fas fa-book"></i> Reference
+            </span>
+          </div>
+        </div>
+
+        <div
+          class="schedule-card"
+          data-aos="fade-up"
+          onclick="openSection(4)"
+          data-section="4"
+        >
+          <div class="card-number">8.4</div>
+          <h3 class="card-title">Incapacity Dismissals</h3>
+          <p class="card-description">
+            Guidelines for dismissals based on poor performance, ill-health, and
+            other incapacity-related issues.
+          </p>
+          <div class="card-footer">
+            <a href="#" class="read-more">
+              Explore Section <i class="fas fa-arrow-right"></i>
+            </a>
+            <span style="color: var(--warning-amber); font-weight: 600">
+              <i class="fas fa-clipboard-check"></i> Complex
+            </span>
+          </div>
+        </div>
+
+        <div
+          class="schedule-card"
+          data-aos="fade-up"
+          onclick="openSection(5)"
+          data-section="5"
+        >
+          <div class="card-number">8.5</div>
+          <h3 class="card-title">Operational Requirements</h3>
+          <p class="card-description">
+            Retrenchment procedures, consultation requirements, and fair
+            selection criteria for operational dismissals.
+          </p>
+          <div class="card-footer">
+            <a href="#" class="read-more">
+              Explore Section <i class="fas fa-arrow-right"></i>
+            </a>
+            <span style="color: var(--success-green); font-weight: 600">
+              <i class="fas fa-users"></i> Critical
+            </span>
+          </div>
+        </div>
+
+        <div
+          class="schedule-card"
+          data-aos="fade-up"
+          onclick="openSection(6)"
+          data-section="6"
+        >
+          <div class="card-number">8.6</div>
+          <h3 class="card-title">Automatically Unfair Dismissals</h3>
+          <p class="card-description">
+            Protected reasons and circumstances where dismissals are
+            automatically considered unfair under the LRA.
+          </p>
+          <div class="card-footer">
+            <a href="#" class="read-more">
+              Explore Section <i class="fas fa-arrow-right"></i>
+            </a>
+            <span style="color: var(--warning-amber); font-weight: 600">
+              <i class="fas fa-shield-alt"></i> Protected
+            </span>
+          </div>
+        </div>
+      </div>
     </section>
     <section class="section" id="flipbook-section">
-        <h2 class="section-title">Interactive Flipbook</h2>
-        <div id="flipbook" class="flipbook">
-            <div class="page"><h3>Section 8.1</h3><p>General Guidelines for Fair Dismissal...</p></div>
-            <div class="page"><h3>Section 8.2</h3><p>Progressive Disciplinary Action...</p></div>
-            <div class="page"><h3>Section 8.3</h3><p>Examples of Misconduct...</p></div>
+      <h2 class="section-title">Interactive Flipbook</h2>
+      <div id="flipbook" class="flipbook">
+        <div class="page">
+          <h3>Section 8.1</h3>
+          <p>General Guidelines for Fair Dismissal...</p>
+        </div>
+        <div class="page">
+          <h3>Section 8.2</h3>
+          <p>Progressive Disciplinary Action...</p>
+        </div>
+        <div class="page">
+          <h3>Section 8.3</h3>
+          <p>Examples of Misconduct...</p>
+        </div>
+      </div>
+    </section>
     <!-- Flipbook Section -->
     <section class="section wow fadeInUp" id="book">
-        <h2 class="section-title">Schedule 8 Flipbook</h2>
-        <div id="flipbook" class="my-flipbook"></div>
+      <h2 class="section-title">Schedule 8 Flipbook</h2>
+      <div id="flipbook" class="my-flipbook"></div>
 
-        <div id="bookPages" style="display:none;">
-            <div class="page">
-                <h3>8.1 General Guidelines</h3>
-                <p>A dismissal must be both substantively and procedurally fair.</p>
-            </div>
-            <div class="page">
-                <h3>8.2 Disciplinary Action</h3>
-                <p>Disciplinary measures should typically be progressive unless misconduct is serious.</p>
-            </div>
-            <div class="page">
-                <h3>8.3 Misconduct Examples</h3>
-                <p>Examples include dishonesty, insubordination, discrimination and more.</p>
-            </div>
-            <div class="page">
-                <h3>8.4 Incapacity Dismissals</h3>
-                <p>Dismissals arising from poor performance or ill-health.</p>
-            </div>
+      <div id="bookPages" style="display: none">
+        <div class="page">
+          <h3>8.1 General Guidelines</h3>
+          <p>A dismissal must be both substantively and procedurally fair.</p>
         </div>
+        <div class="page">
+          <h3>8.2 Disciplinary Action</h3>
+          <p>
+            Disciplinary measures should typically be progressive unless
+            misconduct is serious.
+          </p>
+        </div>
+        <div class="page">
+          <h3>8.3 Misconduct Examples</h3>
+          <p>
+            Examples include dishonesty, insubordination, discrimination and
+            more.
+          </p>
+        </div>
+        <div class="page">
+          <h3>8.4 Incapacity Dismissals</h3>
+          <p>Dismissals arising from poor performance or ill-health.</p>
+        </div>
+      </div>
     </section>
 
     <!-- Interactive Book -->
     <section class="flipbook-section">
-        <h2 class="section-title">Interactive Schedule 8 Book</h2>
-        <div id="flipbook" class="flipbook">
-            <div class="page">
-                <h3>Overview</h3>
-                <p>An engaging summary of Schedule 8 principles for employers and chairpersons.</p>
-            </div>
-            <div class="page">
-                <h3>Progressive Discipline</h3>
-                <p>Clear guidance on warnings and dismissal procedures.</p>
-            </div>
-            <div class="page">
-                <h3>Key Tips</h3>
-                <p>Essential notes to ensure fairness in labour practices.</p>
-            </div>
+      <h2 class="section-title">Interactive Schedule 8 Book</h2>
+      <div id="flipbook" class="flipbook">
+        <div class="page">
+          <h3>Overview</h3>
+          <p>
+            An engaging summary of Schedule 8 principles for employers and
+            chairpersons.
+          </p>
         </div>
+        <div class="page">
+          <h3>Progressive Discipline</h3>
+          <p>Clear guidance on warnings and dismissal procedures.</p>
+        </div>
+        <div class="page">
+          <h3>Key Tips</h3>
+          <p>Essential notes to ensure fairness in labour practices.</p>
+        </div>
+      </div>
     </section>
     <!-- Footer -->
     <footer class="footer">
-        <div class="footer-content">
-            <h3 class="footer-title">Thank You</h3>
-            <p class="footer-message">
-                This interactive Schedule 8 reference tool has been created with care and precision for the dedicated 
-                HR professionals, managers, and legal practitioners who work tirelessly to ensure fair and compliant 
-                employment practices in South Africa.
-            </p>
-            <div class="contact-info">
-                <div class="contact-item">
-                    <i class="fas fa-envelope"></i>
-                    <span>nandi.basson@highcourtadvocate.co.za</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-calendar"></i>
-                    <span>Labour Workshop</span>
-                </div>
-                <div class="contact-item">
-                    <i class="fas fa-map-marker-alt"></i>
-                    <span>South Africa</span>
-                </div>
-            </div>
-            <div class="workshop-date">11-13 June 2025</div>
+      <div class="footer-content">
+        <h3 class="footer-title">Thank You</h3>
+        <p class="footer-message">
+          This interactive Schedule 8 reference tool has been created with care
+          and precision for the dedicated HR professionals, managers, and legal
+          practitioners who work tirelessly to ensure fair and compliant
+          employment practices in South Africa.
+        </p>
+        <div class="contact-info">
+          <div class="contact-item">
+            <i class="fas fa-envelope"></i>
+            <span>nandi.basson@highcourtadvocate.co.za</span>
+          </div>
+          <div class="contact-item">
+            <i class="fas fa-calendar"></i>
+            <span>Labour Workshop</span>
+          </div>
+          <div class="contact-item">
+            <i class="fas fa-map-marker-alt"></i>
+            <span>South Africa</span>
+          </div>
         </div>
+        <div class="workshop-date">11-13 June 2025</div>
+      </div>
     </footer>
 
     <script>
-        // Advanced JavaScript for Interactive Features
-        
-        // Loading Screen Animation
-        window.addEventListener('load', () => {
-            setTimeout(() => {
-                document.getElementById('loadingScreen').classList.add('hidden');
-            }, 2000);
-        });
+              // Advanced JavaScript for Interactive Features
 
-        // Smart Navigation Bar
-        let lastScrollTop = 0;
-        const navbar = document.getElementById('navbar');
-        
-        window.addEventListener('scroll', () => {
-            const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-            
-            if (scrollTop > lastScrollTop && scrollTop > 100) {
-                navbar.classList.add('hidden');
-            } else {
-                navbar.classList.remove('hidden');
-            }
-            
-            lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
-        });
+              // Loading Screen Animation
+              window.addEventListener('load', () => {
+                  setTimeout(() => {
+                      document.getElementById('loadingScreen').classList.add('hidden');
+                  }, 2000);
+              });
 
-        // Section Cards Interaction
-        function openSection(sectionNumber) {
-            // Create a beautiful modal or redirect to detailed section
-            showSectionDetail(sectionNumber);
-        }
+              // Smart Navigation Bar
+              let lastScrollTop = 0;
+              const navbar = document.getElementById('navbar');
 
-        function showSectionDetail(sectionNumber) {
-            // Advanced modal with detailed Schedule 8 content
-            const modal = document.createElement('div');
-            modal.style.cssText = `
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                background: rgba(28, 40, 51, 0.95);
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                z-index: 10000;
-                opacity: 0;
-                transition: opacity 0.3s ease;
-            `;
-            
-            const content = document.createElement('div');
-            content.style.cssText = `
-                background: white;
-                border-radius: 20px;
-                padding: 3rem;
-                max-width: 800px;
-                max-height: 80vh;
-                overflow-y: auto;
-                transform: scale(0.8);
-                transition: transform 0.3s ease;
-            `;
-            
-            content.innerHTML = `
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem;">
-                    <h2 style="font-family: 'Playfair Display', serif; font-size: 2.5rem; color: #1C2833; margin: 0;">
-                        Schedule 8.${sectionNumber}
-                    </h2>
-                    <button onclick="closeModal()" style="background: none; border: none; font-size: 2rem; cursor: pointer; color: #1C2833;">
-                        ×
-                    </button>
-                </div>
-                <div id="sectionContent">
-                    ${getSectionContent(sectionNumber)}
-                </div>
-            `;
-            
-            modal.appendChild(content);
-            document.body.appendChild(modal);
-            
-            // Animate in
-            requestAnimationFrame(() => {
-                modal.style.opacity = '1';
-                content.style.transform = 'scale(1)';
-            });
-            
-            // Store reference for closing
-            window.currentModal = modal;
-        }
+              window.addEventListener('scroll', () => {
+                  const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
 
-        function closeModal() {
-            if (window.currentModal) {
-                window.currentModal.style.opacity = '0';
-                setTimeout(() => {
-                    document.body.removeChild(window.currentModal);
-                    window.currentModal = null;
-                }, 300);
-            }
-        }
+                  if (scrollTop > lastScrollTop && scrollTop > 100) {
+                      navbar.classList.add('hidden');
+                  } else {
+                      navbar.classList.remove('hidden');
+                  }
 
-        function getSectionContent(sectionNumber) {
-            const sections = {
-                1: `
-                    <h3 style="color: #D4AF37; margin-bottom: 1rem;">General Guidelines for Fair Dismissal</h3>
-                    <p style="line-height: 1.8; margin-bottom: 1.5rem;">
-                        A dismissal must be both substantively and procedurally fair to be considered valid under the Labour Relations Act.
-                    </p>
-                    <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
-                        <h4 style="color: #1C2833; margin-bottom: 1rem;">Key Requirements:</h4>
-                        <ul style="line-height: 1.8;">
-                            <li>Fair reason for dismissal must exist</li>
-                            <li>Proper procedure must be followed</li>
-                            <li>Dismissal must be proportionate to the misconduct</li>
-                            <li>Employee must be given opportunity to respond</li>
-                        </ul>
-                    </div>
-                    <p style="font-style: italic; color: #5D6D7E;">
-                        Remember: The onus is on the employer to prove that the dismissal was fair.
-                    </p>
-                `,
-                2: `
-                    <h3 style="color: #D4AF37; margin-bottom: 1rem;">Progressive Disciplinary Action</h3>
-                    <p style="line-height: 1.8; margin-bottom: 1.5rem;">
-                        Disciplinary action should generally be progressive, except in cases of serious misconduct.
-                    </p>
-                    <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
-                        <h4 style="color: #1C2833; margin-bottom: 1rem;">Progressive Steps:</h4>
-                        <ol style="line-height: 1.8;">
-                            <li>Verbal warning</li>
-                            <li>Written warning</li>
-                            <li>Final written warning</li>
-                            <li>Dismissal</li>
-                        </ol>
-                    </div>
-                    <p style="font-style: italic; color: #5D6D7E;">
-                        Consider the employee's disciplinary record and circumstances of the case.
-                    </p>
-                `,
-                3: `
-                    <h3 style="color: #D4AF37; margin-bottom: 1rem;">Examples of Misconduct</h3>
-                    <p style="line-height: 1.8; margin-bottom: 1.5rem;">
-                        Understanding different categories of misconduct helps determine appropriate disciplinary action.
-                    </p>
-                    <div style="display: grid; gap: 1rem; margin-bottom: 1.5rem;">
-                        <div style="background: #FEF9E7; padding: 1rem; border-radius: 8px;">
-                            <h5 style="color: #F39C12; margin-bottom: 0.5rem;">Minor Misconduct</h5>
-                            <p style="margin: 0; font-size: 0.9rem;">Lateness, minor safety violations, inappropriate dress</p>
-                        </div>
-                        <div style="background: #FDEDEC; padding: 1rem; border-radius: 8px;">
-                            <h5 style="color: #E74C3C; margin-bottom: 0.5rem;">Serious Misconduct</h5>
-                            <p style="margin: 0; font-size: 0.9rem;">Dishonesty, insubordination, discrimination, harassment</p>
-                        </div>
-                        <div style="background: #EAEDED; padding: 1rem; border-radius: 8px;">
-                            <h5 style="color: #1C2833; margin-bottom: 0.5rem;">Gross Misconduct</h5>
-                            <p style="margin: 0; font-size: 0.9rem;">Theft, assault, fraud, serious safety violations</p>
-                        </div>
-                    </div>
-                `,
-                4: `
-                    <h3 style="color: #D4AF37; margin-bottom: 1rem;">Incapacity Dismissals</h3>
-                    <p style="line-height: 1.8; margin-bottom: 1.5rem;">
-                        Dismissals based on employee's inability to perform duties due to poor performance or ill-health.
-                    </p>
-                    <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
-                        <h4 style="color: #1C2833; margin-bottom: 1rem;">Requirements:</h4>
-                        <ul style="line-height: 1.8;">
-                            <li>Performance standards must be clear</li>
-                            <li>Employee must be made aware of shortcomings</li>
-                            <li>Reasonable opportunity to improve must be given</li>
-                            <li>Consider alternative employment if possible</li>
-                        </ul>
-                    </div>
-                `,
-                5: `
-                    <h3 style="color: #D4AF37; margin-bottom: 1rem;">Operational Requirements</h3>
-                    <p style="line-height: 1.8; margin-bottom: 1.5rem;">
-                        Dismissals due to business needs, including retrenchments and restructuring.
-                    </p>
-                    <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
-                        <h4 style="color: #1C2833; margin-bottom: 1rem;">Consultation Requirements:</h4>
-                        <ul style="line-height: 1.8;">
-                            <li>Meaningful consultation with employees/representatives</li>
-                            <li>Explore alternatives to dismissal</li>
-                            <li>Fair selection criteria if dismissals necessary</li>
-                            <li>Consider redeployment opportunities</li>
-                        </ul>
-                    </div>
-                `,
-                6: `
-                    <h3 style="color: #D4AF37; margin-bottom: 1rem;">Automatically Unfair Dismissals</h3>
-                    <p style="line-height: 1.8; margin-bottom: 1.5rem;">
-                        Certain reasons for dismissal are automatically unfair, regardless of procedure followed.
-                    </p>
-                    <div style="background: #FDEDEC; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
-                        <h4 style="color: #E74C3C; margin-bottom: 1rem;">Protected Reasons Include:</h4>
-                        <ul style="line-height: 1.8;">
-                            <li>Trade union membership or activities</li>
-                            <li>Pregnancy or intended pregnancy</li>
-                            <li>Unfair discrimination</li>
-                            <li>Exercising rights under the LRA</li>
-                            <li>Refusing to do what is unlawful</li>
-                        </ul>
-                    </div>
-                `
-            };
-            
-            return sections[sectionNumber] || `<p>Content for section ${sectionNumber} coming soon...</p>`;
-        }
+                  lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+              });
 
-        // Smooth scrolling for navigation links
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', function (e) {
-                e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
-                if (target) {
-                    target.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'start'
-                    });
-                }
-            });
-        });
+              // Section Cards Interaction
+              function openSection(sectionNumber) {
+                  // Create a beautiful modal or redirect to detailed section
+                  showSectionDetail(sectionNumber);
+              }
 
-        // Enhanced card hover effects
-        document.querySelectorAll('.schedule-card').forEach(card => {
-            card.addEventListener('mouseenter', function() {
-                this.style.transform = 'translateY(-10px) scale(1.02)';
-            });
-            
-            card.addEventListener('mouseleave', function() {
-                this.style.transform = 'translateY(0) scale(1)';
-            });
-        });
+              function showSectionDetail(sectionNumber) {
+                  // Advanced modal with detailed Schedule 8 content
+                  const modal = document.createElement('div');
+                  modal.style.cssText = `
+                      position: fixed;
+                      top: 0;
+                      left: 0;
+                      width: 100%;
+                      height: 100%;
+                      background: rgba(28, 40, 51, 0.95);
+                      display: flex;
+                      align-items: center;
+                      justify-content: center;
+                      z-index: 10000;
+                      opacity: 0;
+                      transition: opacity 0.3s ease;
+                  `;
 
-        // PWA Installation prompt
-        let deferredPrompt;
-        
-        window.addEventListener('beforeinstallprompt', (e) => {
-            e.preventDefault();
-            deferredPrompt = e;
-            
-            // Show custom install button
-            const installButton = document.createElement('button');
-            installButton.innerHTML = '<i class="fas fa-download"></i> Install App';
-            installButton.style.cssText = `
-                position: fixed;
-                bottom: 20px;
-                right: 20px;
-                background: #1C2833;
-                color: white;
-                border: none;
-                padding: 12px 20px;
-                border-radius: 25px;
-                cursor: pointer;
-                font-weight: 600;
-                box-shadow: 0 5px 20px rgba(0,0,0,0.3);
-                z-index: 1000;
-                transition: all 0.3s ease;
-            `;
-            
-            installButton.addEventListener('click', async () => {
-                if (deferredPrompt) {
-                    deferredPrompt.prompt();
-                    const { outcome } = await deferredPrompt.userChoice;
-                    deferredPrompt = null;
-                    document.body.removeChild(installButton);
-                }
-            });
-            
-            document.body.appendChild(installButton);
-        });
+                  const content = document.createElement('div');
+                  content.style.cssText = `
+                      background: white;
+                      border-radius: 20px;
+                      padding: 3rem;
+                      max-width: 800px;
+                      max-height: 80vh;
+                      overflow-y: auto;
+                      transform: scale(0.8);
+                      transition: transform 0.3s ease;
+                  `;
 
-        // Advanced performance monitoring
-        if ('performance' in window) {
-            window.addEventListener('load', () => {
-                setTimeout(() => {
-                    const perfData = performance.getEntriesByType('navigation')[0];
-                    console.log(`Page load time: ${perfData.loadEventEnd - perfData.loadEventStart}ms`);
-                }, 0);
-            });
-        }
-        // Flipbook initialization
-        const loadFlip = () => {
-            if (!document.getElementById('flipbook')) return;
-            const script = document.createElement('script');
-            script.src = 'https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/js/page-flip.browser.min.js';
-            script.onload = () => {
-                const pageFlip = new St.PageFlip(document.getElementById('flipbook'), {
-                    width: 550,
-                    height: 400,
-                    size: 'stretch',
-                    maxShadowOpacity: 0.5,
-                    showCover: false,
-                    mobileScrollSupport: false
-                });
-                pageFlip.loadFromHTML(document.querySelectorAll('#flipbook .page'));
-            }            document.body.appendChild(script);
-        };
-        document.addEventListener('DOMContentLoaded', loadFlip);
-    const idx=lunr(function(){this.field("title");this.field("body");document.querySelectorAll("[data-section]").forEach(s=>{this.add({id:s.id,title:s.querySelector(".card-title")?s.querySelector(".card-title").textContent:"",body:s.textContent});});});document.getElementById("searchBox").addEventListener("input",e=>{console.log(idx.search(e.target.value));});
-        if (window.Typed) { new Typed('#typed-subtitle', { strings: ['Your Essential Guide to Employment Discipline', 'Explore Schedule 8 with confidence'], typeSpeed: 40, backSpeed: 20, loop: true }); }
-    $("#flipbook").turn({width:400,height:500,autoCenter:true});
-    anime({
-        targets: ".hero-text h1",
-        translateY: [-50,0],
-        opacity: [0,1],
-        duration: 800,
-        easing: "easeOutQuad"
-    });
-// Initialize AOS animations
-AOS.init({ once: true });
+                  content.innerHTML = `
+                      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem;">
+                          <h2 style="font-family: 'Playfair Display', serif; font-size: 2.5rem; color: #1C2833; margin: 0;">
+                              Schedule 8.${sectionNumber}
+                          </h2>
+                          <button onclick="closeModal()" style="background: none; border: none; font-size: 2rem; cursor: pointer; color: #1C2833;">
+                              ×
+                          </button>
+                      </div>
+                      <div id="sectionContent">
+                          ${getSectionContent(sectionNumber)}
+                      </div>
+                  `;
 
-$(document).ready(function() {
-    if (window['$'] && document.getElementById('flipbook')) {
-        $('#flipbook').turn({
-            width: 600,
-            height: 400,
-            autoCenter: true
-        });
-    }
-});
+                  modal.appendChild(content);
+                  document.body.appendChild(modal);
 
-const documents = [
-    { id: 1, title: 'General Guidelines', body: 'A dismissal must be both substantively and procedurally fair to be valid.' },
-    { id: 2, title: 'Progressive Disciplinary Action', body: 'Disciplinary action should generally be progressive.' },
-    { id: 3, title: 'Examples of Misconduct', body: 'Understanding different categories of misconduct helps determine action.' }
-];
-const idx = lunr(function() {
-    this.ref('id');
-    this.field('title');
-    this.field('body');
-    documents.forEach(d => this.add(d));
-});
-const searchInput = document.getElementById('searchInput');
-const searchResults = document.getElementById('searchResults');
-if (searchInput) {
-    searchInput.addEventListener('input', () => {
-        const results = idx.search(searchInput.value);
-        searchResults.innerHTML = results.map(r => {
-            const doc = documents.find(d => d.id == r.ref);
-            return `<div class="search-result"><strong>${doc.title}</strong><p>${doc.body}</p></div>`;
-        }).join('') || '<p style="color:#5D6D7E;">No results found</p>';
-    });
-}
-        // Initialize WOW animations and Flipbook
-        if (typeof WOW === "function") {
-            new WOW().init();
-        }
+                  // Animate in
+                  requestAnimationFrame(() => {
+                      modal.style.opacity = '1';
+                      content.style.transform = 'scale(1)';
+                  });
 
-        if (window.ScrollMagic) {
-            const controller = new ScrollMagic.Controller();
-            document.querySelectorAll('.section').forEach(sec => {
-                new ScrollMagic.Scene({ triggerElement: sec, triggerHook: 0.9 })
-                    .setClassToggle(sec, 'visible')
-                    .addTo(controller);
-            });
-        }
+                  // Store reference for closing
+                  window.currentModal = modal;
+              }
 
-        if (window.lottie) {
-            lottie.loadAnimation({
-                container: document.getElementById('hero-animation'),
-                renderer: 'svg',
-                loop: true,
-                autoplay: true,
-                path: 'https://assets1.lottiefiles.com/packages/lf20_x62chJ.json'
-            });
-        }
+              function closeModal() {
+                  if (window.currentModal) {
+                      window.currentModal.style.opacity = '0';
+                      setTimeout(() => {
+                          document.body.removeChild(window.currentModal);
+                          window.currentModal = null;
+                      }, 300);
+                  }
+              }
 
-        if (window.St && document.getElementById("flipbook")) {
-            const pageFlip = new St.PageFlip(document.getElementById("flipbook"), {
-                width: 600,
-                height: 400,
-                size: "stretch",
-                maxShadowOpacity: 0.5,
-                showCover: false
-            });
-            pageFlip.loadFromHTML(document.querySelectorAll("#bookPages .page"));
-        }
+              function getSectionContent(sectionNumber) {
+                  const sections = {
+                      1: `
+                          <h3 style="color: #D4AF37; margin-bottom: 1rem;">General Guidelines for Fair Dismissal</h3>
+                          <p style="line-height: 1.8; margin-bottom: 1.5rem;">
+                              A dismissal must be both substantively and procedurally fair to be considered valid under the Labour Relations Act.
+                          </p>
+                          <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
+                              <h4 style="color: #1C2833; margin-bottom: 1rem;">Key Requirements:</h4>
+                              <ul style="line-height: 1.8;">
+                                  <li>Fair reason for dismissal must exist</li>
+                                  <li>Proper procedure must be followed</li>
+                                  <li>Dismissal must be proportionate to the misconduct</li>
+                                  <li>Employee must be given opportunity to respond</li>
+                              </ul>
+                          </div>
+                          <p style="font-style: italic; color: #5D6D7E;">
+                              Remember: The onus is on the employer to prove that the dismissal was fair.
+                          </p>
+                      `,
+                      2: `
+                          <h3 style="color: #D4AF37; margin-bottom: 1rem;">Progressive Disciplinary Action</h3>
+                          <p style="line-height: 1.8; margin-bottom: 1.5rem;">
+                              Disciplinary action should generally be progressive, except in cases of serious misconduct.
+                          </p>
+                          <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
+                              <h4 style="color: #1C2833; margin-bottom: 1rem;">Progressive Steps:</h4>
+                              <ol style="line-height: 1.8;">
+                                  <li>Verbal warning</li>
+                                  <li>Written warning</li>
+                                  <li>Final written warning</li>
+                                  <li>Dismissal</li>
+                              </ol>
+                          </div>
+                          <p style="font-style: italic; color: #5D6D7E;">
+                              Consider the employee's disciplinary record and circumstances of the case.
+                          </p>
+                      `,
+                      3: `
+                          <h3 style="color: #D4AF37; margin-bottom: 1rem;">Examples of Misconduct</h3>
+                          <p style="line-height: 1.8; margin-bottom: 1.5rem;">
+                              Understanding different categories of misconduct helps determine appropriate disciplinary action.
+                          </p>
+                          <div style="display: grid; gap: 1rem; margin-bottom: 1.5rem;">
+                              <div style="background: #FEF9E7; padding: 1rem; border-radius: 8px;">
+                                  <h5 style="color: #F39C12; margin-bottom: 0.5rem;">Minor Misconduct</h5>
+                                  <p style="margin: 0; font-size: 0.9rem;">Lateness, minor safety violations, inappropriate dress</p>
+                              </div>
+                              <div style="background: #FDEDEC; padding: 1rem; border-radius: 8px;">
+                                  <h5 style="color: #E74C3C; margin-bottom: 0.5rem;">Serious Misconduct</h5>
+                                  <p style="margin: 0; font-size: 0.9rem;">Dishonesty, insubordination, discrimination, harassment</p>
+                              </div>
+                              <div style="background: #EAEDED; padding: 1rem; border-radius: 8px;">
+                                  <h5 style="color: #1C2833; margin-bottom: 0.5rem;">Gross Misconduct</h5>
+                                  <p style="margin: 0; font-size: 0.9rem;">Theft, assault, fraud, serious safety violations</p>
+                              </div>
+                          </div>
+                      `,
+                      4: `
+                          <h3 style="color: #D4AF37; margin-bottom: 1rem;">Incapacity Dismissals</h3>
+                          <p style="line-height: 1.8; margin-bottom: 1.5rem;">
+                              Dismissals based on employee's inability to perform duties due to poor performance or ill-health.
+                          </p>
+                          <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
+                              <h4 style="color: #1C2833; margin-bottom: 1rem;">Requirements:</h4>
+                              <ul style="line-height: 1.8;">
+                                  <li>Performance standards must be clear</li>
+                                  <li>Employee must be made aware of shortcomings</li>
+                                  <li>Reasonable opportunity to improve must be given</li>
+                                  <li>Consider alternative employment if possible</li>
+                              </ul>
+                          </div>
+                      `,
+                      5: `
+                          <h3 style="color: #D4AF37; margin-bottom: 1rem;">Operational Requirements</h3>
+                          <p style="line-height: 1.8; margin-bottom: 1.5rem;">
+                              Dismissals due to business needs, including retrenchments and restructuring.
+                          </p>
+                          <div style="background: #F8F9FA; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
+                              <h4 style="color: #1C2833; margin-bottom: 1rem;">Consultation Requirements:</h4>
+                              <ul style="line-height: 1.8;">
+                                  <li>Meaningful consultation with employees/representatives</li>
+                                  <li>Explore alternatives to dismissal</li>
+                                  <li>Fair selection criteria if dismissals necessary</li>
+                                  <li>Consider redeployment opportunities</li>
+                              </ul>
+                          </div>
+                      `,
+                      6: `
+                          <h3 style="color: #D4AF37; margin-bottom: 1rem;">Automatically Unfair Dismissals</h3>
+                          <p style="line-height: 1.8; margin-bottom: 1.5rem;">
+                              Certain reasons for dismissal are automatically unfair, regardless of procedure followed.
+                          </p>
+                          <div style="background: #FDEDEC; padding: 1.5rem; border-radius: 10px; margin-bottom: 1.5rem;">
+                              <h4 style="color: #E74C3C; margin-bottom: 1rem;">Protected Reasons Include:</h4>
+                              <ul style="line-height: 1.8;">
+                                  <li>Trade union membership or activities</li>
+                                  <li>Pregnancy or intended pregnancy</li>
+                                  <li>Unfair discrimination</li>
+                                  <li>Exercising rights under the LRA</li>
+                                  <li>Refusing to do what is unlawful</li>
+                              </ul>
+                          </div>
+                      `
+                  };
+
+                  return sections[sectionNumber] || `<p>Content for section ${sectionNumber} coming soon...</p>`;
+              }
+
+              // Smooth scrolling for navigation links
+              document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+                  anchor.addEventListener('click', function (e) {
+                      e.preventDefault();
+                      const target = document.querySelector(this.getAttribute('href'));
+                      if (target) {
+                          target.scrollIntoView({
+                              behavior: 'smooth',
+                              block: 'start'
+                          });
+                      }
+                  });
+              });
+
+              // Enhanced card hover effects
+              document.querySelectorAll('.schedule-card').forEach(card => {
+                  card.addEventListener('mouseenter', function() {
+                      this.style.transform = 'translateY(-10px) scale(1.02)';
+                  });
+
+                  card.addEventListener('mouseleave', function() {
+                      this.style.transform = 'translateY(0) scale(1)';
+                  });
+              });
+
+              // PWA Installation prompt
+              let deferredPrompt;
+
+              window.addEventListener('beforeinstallprompt', (e) => {
+                  e.preventDefault();
+                  deferredPrompt = e;
+
+                  // Show custom install button
+                  const installButton = document.createElement('button');
+                  installButton.innerHTML = '<i class="fas fa-download"></i> Install App';
+                  installButton.style.cssText = `
+                      position: fixed;
+                      bottom: 20px;
+                      right: 20px;
+                      background: #1C2833;
+                      color: white;
+                      border: none;
+                      padding: 12px 20px;
+                      border-radius: 25px;
+                      cursor: pointer;
+                      font-weight: 600;
+                      box-shadow: 0 5px 20px rgba(0,0,0,0.3);
+                      z-index: 1000;
+                      transition: all 0.3s ease;
+                  `;
+
+                  installButton.addEventListener('click', async () => {
+                      if (deferredPrompt) {
+                          deferredPrompt.prompt();
+                          const { outcome } = await deferredPrompt.userChoice;
+                          deferredPrompt = null;
+                          document.body.removeChild(installButton);
+                      }
+                  });
+
+                  document.body.appendChild(installButton);
+              });
+
+              // Advanced performance monitoring
+              if ('performance' in window) {
+                  window.addEventListener('load', () => {
+                      setTimeout(() => {
+                          const perfData = performance.getEntriesByType('navigation')[0];
+                          console.log(`Page load time: ${perfData.loadEventEnd - perfData.loadEventStart}ms`);
+                      }, 0);
+                  });
+              }
+              // Flipbook initialization
+              const loadFlip = () => {
+                  if (!document.getElementById('flipbook')) return;
+                  const script = document.createElement('script');
+                  script.src = 'https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/js/page-flip.browser.min.js';
+                  script.onload = () => {
+                      const pageFlip = new St.PageFlip(document.getElementById('flipbook'), {
+                          width: 550,
+                          height: 400,
+                          size: 'stretch',
+                          maxShadowOpacity: 0.5,
+                          showCover: false,
+                          mobileScrollSupport: false
+                      });
+                      pageFlip.loadFromHTML(document.querySelectorAll('#flipbook .page'));
+                  }            document.body.appendChild(script);
+              };
+              document.addEventListener('DOMContentLoaded', loadFlip);
+          const idx=lunr(function(){this.field("title");this.field("body");document.querySelectorAll("[data-section]").forEach(s=>{this.add({id:s.id,title:s.querySelector(".card-title")?s.querySelector(".card-title").textContent:"",body:s.textContent});});});document.getElementById("searchBox").addEventListener("input",e=>{console.log(idx.search(e.target.value));});
+              if (window.Typed) { new Typed('#typed-subtitle', { strings: ['Your Essential Guide to Employment Discipline', 'Explore Schedule 8 with confidence'], typeSpeed: 40, backSpeed: 20, loop: true }); }
+          $("#flipbook").turn({width:400,height:500,autoCenter:true});
+          anime({
+              targets: ".hero-text h1",
+              translateY: [-50,0],
+              opacity: [0,1],
+              duration: 800,
+              easing: "easeOutQuad"
+          });
+      // Initialize AOS animations
+      AOS.init({ once: true });
+
+      $(document).ready(function() {
+          if (window['$'] && document.getElementById('flipbook')) {
+              $('#flipbook').turn({
+                  width: 600,
+                  height: 400,
+                  autoCenter: true
+              });
+          }
+      });
+
+      const documents = [
+          { id: 1, title: 'General Guidelines', body: 'A dismissal must be both substantively and procedurally fair to be valid.' },
+          { id: 2, title: 'Progressive Disciplinary Action', body: 'Disciplinary action should generally be progressive.' },
+          { id: 3, title: 'Examples of Misconduct', body: 'Understanding different categories of misconduct helps determine action.' }
+      ];
+      const idx = lunr(function() {
+          this.ref('id');
+          this.field('title');
+          this.field('body');
+          documents.forEach(d => this.add(d));
+      });
+      const searchInput = document.getElementById('searchInput');
+      const searchResults = document.getElementById('searchResults');
+      if (searchInput) {
+          searchInput.addEventListener('input', () => {
+              const results = idx.search(searchInput.value);
+              searchResults.innerHTML = results.map(r => {
+                  const doc = documents.find(d => d.id == r.ref);
+                  return `<div class="search-result"><strong>${doc.title}</strong><p>${doc.body}</p></div>`;
+              }).join('') || '<p style="color:#5D6D7E;">No results found</p>';
+          });
+      }
+              // Initialize WOW animations and Flipbook
+              if (typeof WOW === "function") {
+                  new WOW().init();
+              }
+
+              if (window.ScrollMagic) {
+                  const controller = new ScrollMagic.Controller();
+                  document.querySelectorAll('.section').forEach(sec => {
+                      new ScrollMagic.Scene({ triggerElement: sec, triggerHook: 0.9 })
+                          .setClassToggle(sec, 'visible')
+                          .addTo(controller);
+                  });
+              }
+
+              if (window.lottie) {
+                  lottie.loadAnimation({
+                      container: document.getElementById('hero-animation'),
+                      renderer: 'svg',
+                      loop: true,
+                      autoplay: true,
+                      path: 'https://assets1.lottiefiles.com/packages/lf20_x62chJ.json'
+                  });
+              }
+
+              if (window.St && document.getElementById("flipbook")) {
+                  const pageFlip = new St.PageFlip(document.getElementById("flipbook"), {
+                      width: 600,
+                      height: 400,
+                      size: "stretch",
+                      maxShadowOpacity: 0.5,
+                      showCover: false
+                  });
+                  pageFlip.loadFromHTML(document.querySelectorAll("#bookPages .page"));
+              }
     </script>
     <script src="jquery.min.js"></script>
     <script src="turn.min.js"></script>
     <script src="lunr.min.js"></script>
     <script src="aos.js"></script>
-</body>
+  </body>
 </html>

--- a/startup.sh
+++ b/startup.sh
@@ -61,6 +61,7 @@ install_global_packages(){
     nodemon
     concurrently
     cross-env
+    pm2
   )
   for pkg in "${packages[@]}"; do
     if npm list -g "$pkg" >/dev/null 2>&1; then
@@ -125,6 +126,9 @@ install_local_packages(){
     eslint-plugin-security
     @commitlint/cli
     @commitlint/config-conventional
+    htmlhint
+    stylelint
+    markdownlint-cli
   )
   log "Installing project dependencies"
   npm install --save "${deps[@]}"


### PR DESCRIPTION
## Summary
- fix malformed `<section>` blocks in `schedule8-masterpiece.html`
- add closing tags for flipbook section
- expand startup tooling with pm2, htmlhint, stylelint and markdownlint
- ignore vendor assets in `.prettierignore`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: No test files found)*
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_684dcde108208320a53356f9fc3e1f61