### PR TITLE
Improve startup script

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,5 @@ aos.css
 README.md
 tsconfig.json
 eslint.config.js
+lra-full.html
+schedule8-offline.html

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Interactive reference for Section 8 of the South African Labour Relations Act.
 - Quick text search across sections using [lunr.js](https://lunrjs.com/)
 - Responsive design with professional typography
 - Setup script `startup.sh` installs required libraries and developer tooling
+- Startup script also installs tools like **pnpm**, **gulp-cli**, **commitizen**,
+  **typedoc**, **esbuild**, **turbo**, **lerna**, **vercel**, and **netlify-cli** for a streamlined modern workflow
 - Additional book libraries (PageFlip, ScrollMagic, Paged.js), epub.js for eBook rendering, OpenSeadragon for high-resolution images, FullPage.js for smooth transitions, and Typed.js for animated text
 
 ## Setup

--- a/startup.sh
+++ b/startup.sh
@@ -76,6 +76,14 @@ install_global_packages(){
     parcel-bundler
     serve
     eslint_d
+    commitizen
+    cz-conventional-changelog
+    typedoc
+    esbuild
+    turbo
+    lerna
+    vercel
+    netlify-cli
   )
   for pkg in "${packages[@]}"; do
     if npm list -g "$pkg" >/dev/null 2>&1; then
@@ -122,6 +130,11 @@ install_local_packages(){
     typed.js
     lottie-web
     dotenv
+    express
+    cors
+    helmet
+    body-parser
+    morgan
   )
   local dev_deps=(
     eslint
@@ -169,6 +182,16 @@ install_local_packages(){
     parcel-bundler
     serve
     eslint_d
+    ts-jest
+    @types/jest
+    jest-environment-jsdom
+    @testing-library/jest-dom
+    @testing-library/react
+    @testing-library/user-event
+    supertest
+    eslint-plugin-compat
+    stylelint-config-standard
+    eslint-plugin-jsdoc
   )
   log "Installing project dependencies"
   npm install --save "${deps[@]}"


### PR DESCRIPTION
## Summary
- beef up global and dev dependencies in setup script
- ignore offline HTML docs in Prettier checks
- document new tooling in the README

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_684de5cb01f88320ba9913fdc6a4628d