### PR TITLE
Improve setup script with VS Code and DevTools extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides an interactive reference for Schedule 8 of the Labour Rela
 
 ## Setup
 
-Run the `startup.sh` script to install recommended tooling and libraries. The script now supports Linux, macOS and Windows (via Chocolatey) and installs Node.js, Docker and a host of developer utilities including GitBook and Docusaurus.
+Run the `startup.sh` script to install recommended tooling and libraries. The script now supports Linux, macOS and Windows (via Chocolatey) and installs Node.js, Docker and a host of developer utilities including GitBook and Docusaurus. It also installs recommended VS Code extensions and opens the React DevTools extension page for Chrome.
 
 ```bash
 ./startup.sh

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -2,7 +2,8 @@
 
 This project includes a comprehensive environment bootstrap script called `startup.sh`.
 The script installs Node.js, Docker, and an extensive suite of developer tools.
-It can be executed multiple times safely.
+It will also install recommended VS Code extensions and open the React DevTools page in your default browser.
+The script is idempotent and can be executed multiple times safely.
 
 ```bash
 ./startup.sh

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -5,3 +5,4 @@
 - **ESLint issues**: Run `npx eslint --fix .` to automatically fix problems.
 - **Prettier format warnings**: Execute `npx prettier --write .`.
 - **Verification script fails**: Ensure all dependencies are installed by running `./startup.sh` again.
+- **VS Code extensions missing**: Install [Visual Studio Code](https://code.visualstudio.com/) and re-run `./startup.sh` to automatically install the recommended extensions.


### PR DESCRIPTION
## Summary
- extend `startup.sh` with `jq` installation and VS Code/Chrome tooling
- install extra global and dev dependencies
- add docs on the new automation

## Testing
- `npm test`
- `bash verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_684df4c94aa48320806c9a95b45b84d4