### PR TITLE
Improve startup script and fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - run: rm -rf node_modules package-lock.json
+      - run: rm -rf node_modules
       - run: npm ci
       - run: npm run lint --if-present
       - run: npm run format --if-present

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Interactive reference for Section 8 of the South African Labour Relations Act.
 - Responsive design with professional typography
 - Setup script `startup.sh` installs required libraries and developer tooling
 - Startup script also installs tools like **pnpm**, **gulp-cli**, **commitizen**,
-  **typedoc**, **esbuild**, **turbo**, **lerna**, **vercel**, and **netlify-cli** for a streamlined modern workflow. It now adds linting plugins such as **eslint-plugin-unicorn**, **eslint-plugin-tailwindcss**, **prettier-plugin-tailwindcss** and security tooling like **owasp-dependency-check**.
+  **typedoc**, **esbuild**, **turbo**, **lerna**, **vercel**, and **netlify-cli** for a streamlined modern workflow. It now adds linting plugins such as **eslint-plugin-unicorn**, **eslint-plugin-tailwindcss**, **prettier-plugin-tailwindcss** and security tooling like **owasp-dependency-check**. The dependency set has grown to include **React**, **Vue**, **Svelte**, **Chart.js**, **lodash** and **date-fns** for rapid development.
 - Additional book libraries (PageFlip, ScrollMagic, Paged.js), epub.js for eBook rendering, OpenSeadragon for high-resolution images, FullPage.js for smooth transitions, and Typed.js for animated text
 
 ## Setup

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -2,7 +2,7 @@
 
 This project includes a comprehensive environment bootstrap script called `startup.sh`.
 The script installs Node.js, Docker, and an extensive suite of developer tools.
-It will also install recommended VS Code extensions and open the React DevTools page in your default browser. Recent updates add linting plugins such as `eslint-plugin-unicorn` and security scanning with `owasp-dependency-check`.
+It will also install recommended VS Code extensions and open the React DevTools page in your default browser. Recent updates add linting plugins such as `eslint-plugin-unicorn` and security scanning with `owasp-dependency-check`. Common libraries like React, Vue, Svelte, Chart.js, lodash and date-fns are also installed for convenience.
 The script is idempotent and can be executed multiple times safely.
 
 ```bash

--- a/startup.sh
+++ b/startup.sh
@@ -247,6 +247,16 @@ install_local_packages(){
     body-parser
     morgan
   )
+  # Additional common libraries for new projects
+  deps+=(
+    react
+    react-dom
+    lodash
+    date-fns
+    svelte
+    vue
+    chart.js
+  )
   local dev_deps=(
     eslint
     prettier
@@ -329,6 +339,11 @@ install_local_packages(){
     sass
     semantic-release
     eslint-plugin-vue
+    eslint-plugin-sonarjs
+    eslint-plugin-no-secrets
+    eslint-plugin-regexp
+    eslint-plugin-svelte3
+    svelte-check
   )
   log "Installing project dependencies"
   npm install --save "${deps[@]}"


### PR DESCRIPTION
## Summary
- stop deleting `package-lock.json` so `npm ci` works
- add popular libraries (React, Vue, Svelte, Chart.js etc.) to `startup.sh`
- add extra lint plugins for Svelte and security scanning
- mention new libraries in README and setup guide

## Testing
- `npm ci --omit=optional`
- `npm run lint --if-present`
- `npm run format --if-present`
- `npm test --if-present`
- `npm audit --audit-level=moderate`


------
https://chatgpt.com/codex/tasks/task_e_684dfb31e3c08320be3c649a1bf7c35c