### PR TITLE
Improve gift packaging and setup tools

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ turn.min.js
 aos.js
 aos.css
 .eslintrc.json
+package-lock.json
 .github/workflows/ci.yml
 README.md
 tsconfig.json

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Interactive reference for Section 8 of the South African Labour Relations Act.
 - Setup script `startup.sh` installs required libraries and developer tooling
 - Startup script also installs tools like **pnpm**, **gulp-cli**, **commitizen**,
   **typedoc**, **esbuild**, **turbo**, **lerna**, **vercel**, and **netlify-cli** for a streamlined modern workflow. It now adds linting plugins such as **eslint-plugin-unicorn**, **eslint-plugin-tailwindcss**, **prettier-plugin-tailwindcss** and security tooling like **owasp-dependency-check**. The dependency set has grown to include **React**, **Vue**, **Svelte**, **Chart.js**, **lodash** and **date-fns** for rapid development.
+- Recent updates install **sentry-cli** globally and add dev tools like **cspell**,
+  **prettier-plugin-organize-imports**, **eslint-plugin-react-refresh**,
+  **eslint-plugin-you-dont-need-lodash-underscore** and
+  **eslint-plugin-no-unsanitized** for enhanced quality checks.
 - Additional book libraries (PageFlip, ScrollMagic, Paged.js), epub.js for eBook rendering, OpenSeadragon for high-resolution images, FullPage.js for smooth transitions, and Typed.js for animated text
 
 ## Setup
@@ -76,6 +80,7 @@ And for quick reference to the complete Labour Relations Act, open `lra-full.htm
 
 ## Packaging the Gift
 
-Run `./package_gift.sh` to produce `gift-package.zip` containing the offline
-HTML pages and supporting assets. Share this archive to provide a
+Run `./package_gift.sh` to produce `gift-package.zip` containing both
+`schedule8-offline.html` and `schedule8-masterpiece.html` along with
+their supporting CSS and JavaScript assets. Share this archive to provide a
 self-contained reference that works without an internet connection.

--- a/package_gift.sh
+++ b/package_gift.sh
@@ -32,9 +32,9 @@ main(){
   log "Packaging offline gift"
   ensure_zip
   TMP_DIR=$(mktemp -d)
-  cp schedule8-offline.html "$TMP_DIR/"
+  cp schedule8-offline.html schedule8-masterpiece.html "$TMP_DIR/"
   cp lra-full.html "$TMP_DIR/"
-  cp jquery.min.js lunr.min.js turn.min.js "$TMP_DIR/"
+  cp aos.css aos.js jquery.min.js lunr.min.js turn.min.js "$TMP_DIR/"
   cp README.md "$TMP_DIR/" 2>/dev/null || true
   zip -r gift-package.zip -j "$TMP_DIR"/*
   rm -r "$TMP_DIR"

--- a/startup.sh
+++ b/startup.sh
@@ -158,6 +158,7 @@ install_global_packages(){
     esbuild
     turbo
     lerna
+    sentry-cli
     vercel
     netlify-cli
     create-react-app
@@ -343,6 +344,11 @@ install_local_packages(){
     eslint-plugin-no-secrets
     eslint-plugin-regexp
     eslint-plugin-svelte3
+    eslint-plugin-react-refresh
+    eslint-plugin-you-dont-need-lodash-underscore
+    eslint-plugin-no-unsanitized
+    prettier-plugin-organize-imports
+    cspell
     svelte-check
   )
   log "Installing project dependencies"


### PR DESCRIPTION
## Summary
- bundle extra files in `package_gift.sh`
- document updated gift instructions and new dev tools
- ignore `package-lock.json` for formatting checks
- add `sentry-cli` and additional linting packages to the setup script

## Testing
- `npx prettier --check .`
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_684dff4fbd608320b54cce91357f0ced