### PR TITLE
Improve gift packaging and startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,7 @@ And for quick reference to the complete Labour Relations Act, open `lra-full.htm
 ## Packaging the Gift
 
 Run `./package_gift.sh` to produce `gift-package.zip` containing the offline
-HTML pages and supporting assets. Share this archive to provide a
-self-contained reference that works without an internet connection.
+HTML pages and supporting assets. Use `-m` to also include
+`schedule8-masterpiece.html`, `-o <file>` to set the output name and
+`--format tar` to create a tarball instead of a zip archive. Share this archive
+to provide a self-contained reference that works without an internet connection.

--- a/package_gift.sh
+++ b/package_gift.sh
@@ -28,17 +28,46 @@ ensure_zip(){
   fi
 }
 
+usage(){
+  echo "Usage: $0 [-o output] [-m] [--format zip|tar]" >&2
+  exit 1
+}
+
 main(){
+  local output="gift-package.zip"
+  local include_masterpiece=false
+  local format="zip"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output)
+        output="$2"; shift 2;;
+      -m|--include-masterpiece)
+        include_masterpiece=true; shift;;
+      --format)
+        format="$2"; shift 2;;
+      -h|--help)
+        usage;;
+      *)
+        err "Unknown option: $1"; usage;;
+    esac
+  done
+
   log "Packaging offline gift"
   ensure_zip
   TMP_DIR=$(mktemp -d)
   cp schedule8-offline.html "$TMP_DIR/"
+  $include_masterpiece && cp schedule8-masterpiece.html "$TMP_DIR/"
   cp lra-full.html "$TMP_DIR/"
   cp jquery.min.js lunr.min.js turn.min.js "$TMP_DIR/"
   cp README.md "$TMP_DIR/" 2>/dev/null || true
-  zip -r gift-package.zip -j "$TMP_DIR"/*
+  if [ "$format" = "tar" ]; then
+    tar -czf "$output" -C "$TMP_DIR" .
+  else
+    zip -r "$output" -j "$TMP_DIR"/* >/dev/null
+  fi
   rm -r "$TMP_DIR"
-  log "Created gift-package.zip"
+  log "Created $output"
 }
 
 main "$@"

--- a/startup.sh
+++ b/startup.sh
@@ -188,6 +188,8 @@ install_global_packages(){
     grunt-cli
     typescript-language-server
     eslint-language-server
+    serverless
+    aws-cdk
   )
   for pkg in "${packages[@]}"; do
     if npm list -g "$pkg" >/dev/null 2>&1; then
@@ -359,6 +361,9 @@ install_local_packages(){
     eslint-plugin-n
     prettier-plugin-organize-imports
     stylelint-scss
+    depcheck
+    eslint-plugin-you-dont-need-lodash-underscore
+    jest-html-reporters
   )
   log "Installing project dependencies"
   npm install --save "${deps[@]}"


### PR DESCRIPTION
## Summary
- add `serverless` and `aws-cdk` to global packages in `startup.sh`
- add `depcheck`, `eslint-plugin-you-dont-need-lodash-underscore` and `jest-html-reporters` dev deps
- enhance `package_gift.sh` with CLI options for output name, format, and including `schedule8-masterpiece.html`
- document new packaging options in README

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e0bc0a9f4832097b70e3c2aa91028