### PR TITLE
Add standalone HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This project offers a unique digital experience for employers and chairpersons t
 - Works offline as a PWA
 
 Open `schedule8-masterpiece.html` in a modern web browser to begin. For an all-in-one page with no external dependencies, open `schedule8-offline.html`.
+If you prefer everything bundled into a single standalone file (with scripts and styles inline), open `schedule8-single.html`.
 And for quick reference to the complete Labour Relations Act, open `lra-full.html`.
 For a lightweight React-based interface that fetches the Act text dynamically, open `lra-react.html` (best served via `http-server`).
 

--- a/inline.js
+++ b/inline.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+let html = fs.readFileSync('schedule8-offline.html', 'utf8');
+
+function inlineCSS(file) {
+  const css = fs.readFileSync(file, 'utf8');
+  const tag = `<link rel="stylesheet" href="${file}" />`;
+  html = html.split(tag).join(`<style>\n${css}\n</style>`);
+}
+
+function inlineJS(file) {
+  const js = fs.readFileSync(file, 'utf8');
+  const tag = `<script src="${file}"></script>`;
+  html = html.split(tag).join(`<script>\n${js}\n</script>`);
+}
+
+['stPageFlip.css', 'aos.css', 'animate.min.css'].forEach(inlineCSS);
+[
+  'wow.min.js',
+  'page-flip.browser.js',
+  'ScrollMagic.min.js',
+  'gsap.min.js',
+  'paged.polyfill.js',
+  'lottie.min.js',
+  'typed.umd.js',
+  'fullpage.min.js',
+  'openseadragon.min.js',
+  'epub.min.js',
+  'jquery.min.js',
+  'turn.min.js',
+  'anime.min.js',
+  'lunr.min.js',
+  'aos.js',
+].forEach(inlineJS);
+
+const hero = fs.readFileSync('hero-animation.json', 'utf8');
+html = html.replace(/path: 'hero-animation.json'/g, `animationData: ${hero}`);
+
+fs.writeFileSync('schedule8-single.html', html);


### PR DESCRIPTION
## Summary
- generate `schedule8-single.html` by inlining all CSS and JS
- document the standalone option in README

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f194319cc8320abb17c365dfbe365